### PR TITLE
Build for Pico 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,22 @@ jobs:
           git submodule update --init --recursive
       - name: 'Configure'
         run: |
-          mkdir -p build
-          cmake -B build
+          mkdir -p build-pico{,2}
+          cmake -B build-pico
+          cmake -B build-pico2 -DPICO_BOARD=pico2 
       - name: 'Build'
         run: |
-          make -C build
-      - name: 'Upload binary'
+          make -C build-pico
+          make -C build-pico2
+      - name: 'Upload Pico binary'
         uses: actions/upload-artifact@v3
         with:
           name: pico-uart-bridge.uf2
-          path: build/uart_bridge.uf2
+          path: build-pico/uart_bridge.uf2
+          retention-days: 5
+      - name: 'Upload Pico 2 binary'
+        uses: actions/upload-artifact@v3
+        with:
+          name: pico2-uart-bridge.uf2
+          path: build-pico2/uart_bridge.uf2
           retention-days: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,17 +33,29 @@ jobs:
           git submodule update --init --recursive
       - name: 'Configure'
         run: |
-          mkdir -p build
-          cmake -B build
+          mkdir -p build-pico
+          cmake -B build-pico
+          mkdir -p build-pico2
+          cmake -B build-pico2 -DPICO_BOARD=pico2
       - name: 'Build'
         run: |
-          make -C build
-      - name: Upload uf2
+          make -C build-pico
+          make -C build-pico2
+      - name: Upload uf2 for Pico
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_name: pico-sexa-uart-bridge-${{ inputs.tag }}.uf2
-          asset_path: build/uart_bridge.uf2
+          asset_path: build-pico/uart_bridge.uf2
+          asset_content_type: application/octet-stream
+      - name: Upload uf2 for Pico 2
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_name: pico2-sexa-uart-bridge-${{ inputs.tag }}.uf2
+          asset_path: build-pico2/uart_bridge.uf2
           asset_content_type: application/octet-stream


### PR DESCRIPTION
It is easy to add support for Pico 2. Adding `-DPICO_BOARD=pico2` to the cmake command is all that is needed.
Two build directories can be created, one for each device: `build-pico` and `build-pico2`